### PR TITLE
Test that bullboard 6.2.3 works

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.12.6",
       "dependencies": {
         "@bl1231/bilbomd-mongodb-schema": "^1.2.11",
-        "@bull-board/api": "^5.23.0",
-        "@bull-board/express": "^5.23.0",
+        "@bull-board/api": "^6.2.3",
+        "@bull-board/express": "^6.2.3",
         "axios": "^1.7.7",
         "bullmq": "^5.21.1",
         "cookie-parser": "~1.4.7",
@@ -1913,36 +1913,36 @@
       }
     },
     "node_modules/@bull-board/api": {
-      "version": "5.23.0",
-      "resolved": "https://registry.npmjs.org/@bull-board/api/-/api-5.23.0.tgz",
-      "integrity": "sha512-ZZGsWJ+XBG49GAlNgAL9tTEV6Ms7gMkQnZDbzwUhjGChCKWy62RWuPoZSefNXau9QH9+QzlzHRUeFvt4xr5wiw==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/@bull-board/api/-/api-6.2.3.tgz",
+      "integrity": "sha512-WwXb6A4St4G7brf9l0ye/dtDHqerC4iAX2d7MTkIGihPVXfCGqmjKhbsWrBLAAdL0kep6SfDlWuN0YTvgYL0xA==",
       "license": "MIT",
       "dependencies": {
         "redis-info": "^3.0.8"
       },
       "peerDependencies": {
-        "@bull-board/ui": "5.23.0"
+        "@bull-board/ui": "6.2.3"
       }
     },
     "node_modules/@bull-board/express": {
-      "version": "5.23.0",
-      "resolved": "https://registry.npmjs.org/@bull-board/express/-/express-5.23.0.tgz",
-      "integrity": "sha512-t/mHzJMlZBtSKD8v81kbZoexOmtQxKVnHZfHJ0um5vrkHNJJuzKuwbR+n9nf1u89AGdyXoWxqDhBDslxv3zrrQ==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/@bull-board/express/-/express-6.2.3.tgz",
+      "integrity": "sha512-Z2UgT3nUTfo9cx6LAsnVwc8a3ZzGXm64Q12lZ0h7vUfhtIicygx8KvigLDW9Xp3d+zh29gi9A3r/+pGschjJxw==",
       "license": "MIT",
       "dependencies": {
-        "@bull-board/api": "5.23.0",
-        "@bull-board/ui": "5.23.0",
+        "@bull-board/api": "6.2.3",
+        "@bull-board/ui": "6.2.3",
         "ejs": "^3.1.10",
         "express": "^4.19.2"
       }
     },
     "node_modules/@bull-board/ui": {
-      "version": "5.23.0",
-      "resolved": "https://registry.npmjs.org/@bull-board/ui/-/ui-5.23.0.tgz",
-      "integrity": "sha512-iI/Ssl8T5ZEn9s899Qz67m92M6RU8thf/aqD7cUHB2yHmkCjqbw7s7NaODTsyArAsnyu7DGJMWm7EhbfFXDNgQ==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/@bull-board/ui/-/ui-6.2.3.tgz",
+      "integrity": "sha512-xRFcB+8IvaEt4JmJmhxtrmVY0lf5NcHPvTphpeFv9ib39nFU/EfuslT5CWhMsbDb27agTaq5FjUXEw72cD72yA==",
       "license": "MIT",
       "dependencies": {
-        "@bull-board/api": "5.23.0"
+        "@bull-board/api": "6.2.3"
       }
     },
     "node_modules/@colors/colors": {

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   },
   "dependencies": {
     "@bl1231/bilbomd-mongodb-schema": "^1.2.11",
-    "@bull-board/api": "^5.23.0",
-    "@bull-board/express": "^5.23.0",
+    "@bull-board/api": "^6.2.3",
+    "@bull-board/express": "^6.2.3",
     "axios": "^1.7.7",
     "bullmq": "^5.21.1",
     "cookie-parser": "~1.4.7",

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -4,7 +4,7 @@ import { createBullBoard } from '@bull-board/api'
 import { BullMQAdapter } from '@bull-board/api/bullMQAdapter.js'
 import { ExpressAdapter } from '@bull-board/express'
 import { Queue as QueueMQ } from 'bullmq'
-import { verifyJWT } from '../middleware/verifyJWT.js'
+// import { verifyJWT } from '../middleware/verifyJWT.js'
 
 const basePath = '/admin/bullmq'
 
@@ -38,7 +38,7 @@ createBullBoard({
   serverAdapter: serverAdapter
 })
 
-router.use(verifyJWT)
+// router.use(verifyJWT)
 
 router.use('/', serverAdapter.getRouter())
 


### PR DESCRIPTION
The dependabot CI build suggested there might be a problem with this upgrade.
I tested. it works
I remove the verifyJWT middleware from this route for the time being.